### PR TITLE
Add requests to pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ authors = [
   {name = "Charles K. Neimog", email = "charlesneimog@outlook.com"},
 ]
 license = {text = "GPL-3.0-or-later"}
+dependencies = [
+    "requests"
+]
 
 [project.urls]
 "Source Code" = "https://github.com/charlesneimog/anytype-client" 


### PR DESCRIPTION
This change is just to let `pip` install `requests` automatically when you install the client.