### PR TITLE
Generalize API response unpacking for instance creation

### DIFF
--- a/anytype/anytype.py
+++ b/anytype/anytype.py
@@ -6,9 +6,6 @@ from .object import Object
 from .api import apiEndpoints
 from .utils import requires_auth
 
-from rich import print_json
-import json
-
 
 class Anytype:
     def __init__(self) -> None:

--- a/anytype/anytype.py
+++ b/anytype/anytype.py
@@ -77,11 +77,11 @@ class Anytype:
     @requires_auth
     def get_space(self, spaceId: str) -> Space:
         response_data = self._apiEndpoints.getSpace(spaceId)
-        obj = Space()
-        obj._apiEndpoints = self._apiEndpoints
-        for key, value in response_data.get("object", {}).items():
-            obj.__dict__[key] = value
-        return obj
+        space = Space()
+        space._apiEndpoints = self._apiEndpoints
+        for key, value in response_data.get("space", {}).items():
+            space.__dict__[key] = value
+        return space
 
     @requires_auth
     def get_spaces(self, offset=0, limit=10) -> list[Space]:

--- a/anytype/anytype.py
+++ b/anytype/anytype.py
@@ -6,6 +6,9 @@ from .object import Object
 from .api import apiEndpoints
 from .utils import requires_auth
 
+from rich import print_json
+import json
+
 
 class Anytype:
     def __init__(self) -> None:
@@ -76,43 +79,28 @@ class Anytype:
 
     @requires_auth
     def get_space(self, spaceId: str) -> Space:
-        response_data = self._apiEndpoints.getSpace(spaceId)
-        space = Space()
-        space._apiEndpoints = self._apiEndpoints
-        for key, value in response_data.get("space", {}).items():
-            space.__dict__[key] = value
-        return space
+        response = self._apiEndpoints.getSpace(spaceId)
+        data = response.get("space", {})
+        return Space._from_api(self._apiEndpoints, data)
 
     @requires_auth
     def get_spaces(self, offset=0, limit=10) -> list[Space]:
         response = self._apiEndpoints.getSpaces(offset, limit)
-        results = []
-        for data in response.get("data", []):
-            new_item = Space()
-            new_item._apiEndpoints = self._apiEndpoints
-            for key, value in data.items():
-                new_item.__dict__[key] = value
-            results.append(new_item)
-
-        return results
+        return [
+            Space._from_api(self._apiEndpoints, data)
+            for data in response.get("data", [])
+        ]
 
     @requires_auth
     def create_space(self, name: str) -> Space:
-        data = self._apiEndpoints.createSpace(name)
-        new_space = Space()
-        new_space._apiEndpoints = self._apiEndpoints
-        for key, value in data["space"].items():
-            new_space.__dict__[key] = value
-        return new_space
+        response = self._apiEndpoints.createSpace(name)
+        data = response.get("space", {})
+        return Space._from_api(self._apiEndpoints, data)
 
     @requires_auth
     def global_search(self, query, offset=0, limit=10) -> list[Object]:
-        response_data = self._apiEndpoints.globalSearch(query, offset, limit)
-        results = []
-        for data in response_data.get("data", []):
-            new_item = Object()
-            new_item._apiEndpoints = self._apiEndpoints
-            for key, value in data.items():
-                new_item.__dict__[key] = value
-            results.append(new_item)
-        return results
+        response = self._apiEndpoints.globalSearch(query, offset, limit)
+        return [
+            Object._from_api(self._apiEndpoints, data)
+            for data in response.get("data", [])
+        ]

--- a/anytype/api.py
+++ b/anytype/api.py
@@ -1,6 +1,11 @@
 import requests
 from urllib.parse import urlencode
 from datetime import datetime
+from typing import TypeVar, Type
+
+from rich import print_json
+import json
+
 
 MIN_REQUIRED_VERSION = datetime(2025, 3, 17).date()
 API_CONFIG = {
@@ -142,3 +147,20 @@ class apiEndpoints:
     def getTemplates(self, spaceId: str, typeId: str, offset: int, limit: int):
         options = {"offset": offset, "limit": limit}
         return self._request("GET", f"/spaces/{spaceId}/types/{typeId}/templates", params=options)
+
+
+T = TypeVar("T", bound="APIWrapper")
+
+class APIWrapper:
+    _apiEndpoints: apiEndpoints | None = None
+
+    @classmethod
+    def _from_api(cls: Type[T], api: apiEndpoints, data: dict) -> T:
+        instance = cls()
+        instance._apiEndpoints = api
+        instance._add_attrs_from_dict(data)
+        return instance
+
+    def _add_attrs_from_dict(self, data: dict) -> None:
+        for key, value in data.items():
+            self.__dict__[key] = value

--- a/anytype/api.py
+++ b/anytype/api.py
@@ -151,6 +151,7 @@ class apiEndpoints:
 
 T = TypeVar("T", bound="APIWrapper")
 
+
 class APIWrapper:
     _apiEndpoints: apiEndpoints | None = None
 

--- a/anytype/api.py
+++ b/anytype/api.py
@@ -3,9 +3,6 @@ from urllib.parse import urlencode
 from datetime import datetime
 from typing import TypeVar, Type
 
-from rich import print_json
-import json
-
 
 MIN_REQUIRED_VERSION = datetime(2025, 3, 17).date()
 API_CONFIG = {

--- a/anytype/listview.py
+++ b/anytype/listview.py
@@ -1,4 +1,4 @@
-from .api import apiEndpoints
+from .api import apiEndpoints, APIWrapper
 from .object import Object
 from .utils import requires_auth
 
@@ -13,18 +13,14 @@ class ListView:
 
     @requires_auth
     def get_objectsinlistview(self, offset=0, limit=100):
-        response_data = self._apiEndpoints.getObjectsInList(
+        response = self._apiEndpoints.getObjectsInList(
             self.space_id, self.list_id, self.id, offset, limit
         )
 
-        results = []
-        for data in response_data.get("data", []):
-            new_item = Object()
-            new_item._apiEndpoints = self._apiEndpoints
-            for key, value in data.items():
-                new_item.__dict__[key] = value
-            results.append(new_item)
-        return results
+        return [
+            Object._from_api(self._apiEndpoints, data)
+            for data in response.get("data", [])
+        ]
 
     @requires_auth
     def add_objectsinlistview(self, objs: list[Object]) -> None:

--- a/anytype/member.py
+++ b/anytype/member.py
@@ -1,7 +1,7 @@
-from .api import apiEndpoints
+from .api import apiEndpoints, APIWrapper
 
 
-class Member:
+class Member(APIWrapper):
     def __init__(self):
         self._apiEndpoints: apiEndpoints | None = None
         self.type = ""

--- a/anytype/object.py
+++ b/anytype/object.py
@@ -5,11 +5,11 @@ import re
 from .block import Block
 from .type import Type
 from .icon import Icon
-from .api import apiEndpoints
+from .api import apiEndpoints, APIWrapper
 from .utils import requires_auth
 
 
-class Object:
+class Object(APIWrapper):
     def __init__(self):
         self._apiEndpoints: apiEndpoints | None = None
         self.id: str = ""

--- a/anytype/space.py
+++ b/anytype/space.py
@@ -11,6 +11,7 @@ from .utils import requires_auth
 from rich import print_json
 import json
 
+
 class Space(APIWrapper):
     def __init__(self):
         self._apiEndpoints: apiEndpoints | None = None

--- a/anytype/space.py
+++ b/anytype/space.py
@@ -8,9 +8,6 @@ from .icon import Icon
 from .api import apiEndpoints, APIWrapper
 from .utils import requires_auth
 
-from rich import print_json
-import json
-
 
 class Space(APIWrapper):
     def __init__(self):

--- a/anytype/template.py
+++ b/anytype/template.py
@@ -1,7 +1,7 @@
-from .api import apiEndpoints
+from .api import apiEndpoints, APIWrapper
 
 
-class Template:
+class Template(APIWrapper):
     def __init__(self):
         self._apiEndpoints: apiEndpoints | None = None
         self.type = ""

--- a/anytype/type.py
+++ b/anytype/type.py
@@ -2,9 +2,6 @@ from .template import Template
 from .api import apiEndpoints, APIWrapper
 from .utils import requires_auth
 
-from rich import print_json
-import json
-
 
 class Type(APIWrapper):
     def __init__(self, name: str = ""):

--- a/anytype/type.py
+++ b/anytype/type.py
@@ -5,6 +5,7 @@ from .utils import requires_auth
 from rich import print_json
 import json
 
+
 class Type(APIWrapper):
     def __init__(self, name: str = ""):
         self._apiEndpoints: apiEndpoints | None = None
@@ -43,14 +44,17 @@ class Type(APIWrapper):
             raise ValueError(
                 f"Type '{self.name}' does not have " "a template named '{template_name}'"
             )
-    
+
     @requires_auth
     def get_template(self, id: str) -> Template:
         response = self._apiEndpoints.getTemplate(self.space_id, self.id, id)
 
+        # TODO: This API response is unlike the rest, it returns a list for
+        # "data" even though we're asking for info on a single template.
+        # Bug in anytype-heart, or am I misunderstanding?
         datas = response.get("data", [])
         if len(datas) > 1:
-            print(f'getTemplate response data has more than one entry: {response}')
+            print(f"getTemplate response data has more than one entry: {response}")
 
         return Template._from_api(self._apiEndpoints, datas[0])
 

--- a/anytype/utils.py
+++ b/anytype/utils.py
@@ -1,9 +1,11 @@
 from functools import wraps
 
+
 def requires_auth(method):
     @wraps(method)
     def wrapper(self, *args, **kwargs):
         if self._apiEndpoints is None:
             raise Exception("You need to auth first")
         return method(self, *args, **kwargs)
+
     return wrapper

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -24,12 +24,18 @@ def get_apispace() -> Space:
 def test_get_spaces():
     spaces = any.get_spaces()
     assert len(spaces) > 0
-    found_space = False
+
+    api_space = False
     for space in spaces:
         if space.name == "API":
-            found_space = True
+            api_space = space
             break
-    assert found_space
+
+    assert api_space
+
+    api_space2 = any.get_space(api_space.id)
+    assert api_space2 is not None
+    assert api_space2.name == api_space.name
 
 
 def test_missspaceid():


### PR DESCRIPTION
There are a bunch of places throughout the code where it retrieves data from the API, creates an instance of some class, adds an attribute for the `apiEndpoint` instance, and adds attributes for all key/value pairs in the API response data, like this:

```python
obj = Space()
obj._apiEndpoints = self._apiEndpoints
for key, value in response.get("space", {}).items():
    obj.__dict__[key] = value
return obj
```

I moved this "response unpacking" functionality into a class `APIWrapper` with a `@classmethod` named `_from_api` which creates instances like this:

```python
data = response.get("space", {})
return Space._from_api(self._apiEndpoints, data)
```
This pattern was being used for a number of classes in the codebase, so now they just subclass `APIWrapper` to utilize `_from_api`. 

I could have done this in the constructor instead of a separate factory method, but I figured it's better to keep the creation of instances from low-level API data private, in case users are instantiating these classes directly in the future.

Also fixed a bug with `Anytype.get_space` which was looking for a field named `object` in the response data instead of `space` (see first commit).