### PR TITLE
more robust sanitation of property names of objects

### DIFF
--- a/anytype/object.py
+++ b/anytype/object.py
@@ -4,7 +4,7 @@ from .type import Type
 from .icon import Icon
 from .property import Property
 from .api import apiEndpoints, APIWrapper
-from .utils import requires_auth, _ANYTYPE_SYSTEM_RELATIONS
+from .utils import requires_auth, _ANYTYPE_SYSTEM_RELATIONS, sanitize_property_name
 
 
 class Object(APIWrapper):
@@ -63,7 +63,7 @@ class Object(APIWrapper):
         if type is not None:
             self.type = type
             for prop in self.properties:
-                class_prop = prop.name.lower().replace(" ", "_")
+                class_prop = sanitize_property_name(prop.name)
                 if class_prop in notoverdrive:
                     continue
 
@@ -79,7 +79,7 @@ class Object(APIWrapper):
     def __setattr__(self, name, value):
         if "_custom_setters" in self.__dict__ and name in self._custom_setters:
             for prop in self.properties:
-                class_prop = prop.name.lower().replace(" ", "_")
+                class_prop = sanitize_property_name(prop.name)
                 if class_prop == name:
                     self._custom_setters[name]["func"](prop, value)
                     return

--- a/anytype/utils.py
+++ b/anytype/utils.py
@@ -1,4 +1,24 @@
+import re
+import keyword
 from functools import wraps
+
+
+def sanitize_property_name(name: str) -> str:
+    """
+    Sanitizes a property name to be a valid Python attribute name.
+    - Converts to lowercase
+    - Replaces all non-alphanumeric characters with underscores
+    - Ensures the name doesn't start with a number
+    - Ensures the name isn't a Python keyword
+    """
+    # Convert to lowercase and replace non-alphanumeric chars with underscore
+    sanitized = re.sub(r'[^a-z0-9_]', '_', name.lower())
+    
+    # Remove leading numbers by adding underscore
+    if sanitized and (sanitized[0].isdigit() or keyword.iskeyword(sanitized)):
+        sanitized = '_' + sanitized
+        
+    return sanitized
 
 
 def requires_auth(method):


### PR DESCRIPTION
We are using a lot of special characters in our property names (german).
Thus we could not set these properties of objects, as only spaces are being transformed to underscores.
This PR solves it by introducing a new sanitation function in utils.py.
This function is then used in objects.py when adding the properties of a type to the object.