### PR TITLE
Bugfix in object.py

### DIFF
--- a/anytype/object.py
+++ b/anytype/object.py
@@ -197,8 +197,8 @@ class Object(APIWrapper):
 
     def __repr__(self):
         if self.type:
-            if self.type.name != "":
-                return f"<Object(name={self.name}, type={self.type.name})>"
+            if self.type["name"] != "":
+                return f"<Object(name={self.name}, type={self.type["name"]})>"
             else:
                 return f"<Object(name={self.name})>"
         else:


### PR DESCRIPTION
Old code gives the error: `AttributeError: 'dict' object has no attribute 'name'`. This fixes the error.